### PR TITLE
Refactoring HelmRelease values

### DIFF
--- a/kubernetes/base/cert-manager/cert-manager/cert-manager-values.yaml
+++ b/kubernetes/base/cert-manager/cert-manager/cert-manager-values.yaml
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../namespace
-- ./cert-manager.yaml
-configMapGenerator:
-  - name: cert-manager-values
-    files:
-      - values.yaml=cert-manager-values.yaml
-configurations:
-  - kustomizeconfig.yaml
+installCRDs: true
+# extraArgs:
+#   - --enable-certificate-owner-ref=true
+#   - --dns01-recursive-nameservers=1.1.1.1:53
+#   - --dns01-recursive-nameservers-only
+prometheus:
+  enabled: true
+  servicemonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack

--- a/kubernetes/base/cert-manager/cert-manager/cert-manager.yaml
+++ b/kubernetes/base/cert-manager/cert-manager/cert-manager.yaml
@@ -17,7 +17,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: cert-manager
-  namespace: cert-manager
+  # namespace: cert-manager
 spec:
   chart:
     spec:
@@ -31,15 +31,18 @@ spec:
   interval: 5m0s
   releaseName: cert-manager
   targetNamespace: cert-manager
-  values:
-    installCRDs: true
-    # extraArgs:
-    #   - --enable-certificate-owner-ref=true
-    #   - --dns01-recursive-nameservers=1.1.1.1:53
-    #   - --dns01-recursive-nameservers-only
-    prometheus:
-      enabled: true
-      servicemonitor:
-        enabled: true
-        labels:
-          release: kube-prometheus-stack
+  valuesFrom:
+    - kind: ConfigMap
+      name: cert-manager-values
+  # values:
+  #   installCRDs: true
+  #   # extraArgs:
+  #   #   - --enable-certificate-owner-ref=true
+  #   #   - --dns01-recursive-nameservers=1.1.1.1:53
+  #   #   - --dns01-recursive-nameservers-only
+  #   prometheus:
+  #     enabled: true
+  #     servicemonitor:
+  #       enabled: true
+  #       labels:
+  #         release: kube-prometheus-stack

--- a/kubernetes/base/cert-manager/cert-manager/kustomizeconfig.yaml
+++ b/kubernetes/base/cert-manager/cert-manager/kustomizeconfig.yaml
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../namespace
-- ./cert-manager.yaml
-configMapGenerator:
-  - name: cert-manager-values
-    files:
-      - values.yaml=cert-manager-values.yaml
-configurations:
-  - kustomizeconfig.yaml
+nameReference:
+- kind: ConfigMap
+  version: v1
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease


### PR DESCRIPTION
Feature : https://toolkit.fluxcd.io/guides/helmreleases/#refer-to-values-in-configmaps-generated-with-kustomize

BLOCKED BY : https://github.com/kubernetes-sigs/kustomize/issues/1301 (See https://github.com/fluxcd/flux2/issues/445)